### PR TITLE
Show a random dog fact under the dog

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,16 +6,37 @@ import ThemeToggle from '@/components/ThemeToggle';
 
 type Heart = { id: number; x: number };
 
+const DOG_FACTS = [
+    'Dogs can learn over 100 words and gestures.',
+    "A dog's nose print is unique, much like a human fingerprint.",
+    'Dogs can smell about 10,000 to 100,000 times better than humans.',
+    "A wagging tail doesn't always mean a happy dog — direction matters.",
+    'Puppies are born deaf and blind, but their sense of smell works right away.',
+    'Dogs dream just like humans do, and puppies dream more than adults.',
+    "The Basenji is known as the 'barkless dog' — it yodels instead.",
+    'Dogs have three eyelids, including one that keeps their eyes moist.',
+    "A greyhound can reach speeds of up to 45 miles per hour.",
+    'Dogs curl up when they sleep to protect their vital organs — an instinct from their ancestors.',
+    "Dogs' noses are wet to help absorb scent chemicals.",
+    'Petting a dog can lower your blood pressure — and theirs too.',
+];
+
 export default function Page() {
     const [petIntensity, setPetIntensity] = useState(0);
     const [isHappy, setIsHappy] = useState(false);
     const [twitchingEar, setTwitchingEar] = useState<'left' | 'right' | null>(null);
     const [hearts, setHearts] = useState<Heart[]>([]);
     const [bark, setBark] = useState<string | null>(null);
+    const [fact, setFact] = useState<string | null>(null);
 
     const happyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const heartId = useRef(0);
     const cachedBark = useRef<string | null>(null);
+
+    // Pick the fact after mount to avoid a server/client hydration mismatch
+    useEffect(() => {
+        setFact(DOG_FACTS[Math.floor(Math.random() * DOG_FACTS.length)]);
+    }, []);
 
     // Random ear twitch every few seconds
     useEffect(() => {
@@ -236,6 +257,15 @@ export default function Page() {
                         </div>
                     </div>
                 </div>
+                {/* Random dog fact */}
+                {fact && (
+                    <p
+                        className="mt-8 max-w-[600px] text-center text-lg italic text-neutral-500 dark:text-neutral-400 motion-safe:animate-pop-in"
+                        data-oid="dog-fact"
+                    >
+                        {fact}
+                    </p>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
Closes #9

## What
Adds a random dog fact caption below the dog on the home page. A module-level list of 12 hardcoded facts is defined in `src/app/page.tsx`; one is picked at random on each visit and rendered in a small italic caption under the dog.

## How
- The fact is selected in a mount-only `useEffect` rather than during render, so the server-rendered HTML and the first client render match — no React hydration mismatch.
- The caption reuses the existing `pop-in` animation and includes `dark:` text variants so it's legible in both themes.
- No new routes, deps, or API — purely additive UI change, per the issue ("no API needed").

## Test plan
The repo has no test framework (no jest/vitest in package.json), so verification is lint + build + a runtime smoke test:

- `npm run lint` → `✔ No ESLint warnings or errors`
- `npm run build` → succeeds; `/` prerenders as static content (2.65 kB, 103 kB first load)
- Smoke test against `npm run start`:
  - `curl http://localhost:3789` returns the page with `data-oid="dog-wrap"` intact
  - The page's client chunk (`/_next/static/chunks/app/page-be6d8ccbe05757d4.js`) contains the facts array (grep for "nose print" → 1 match), confirming the feature ships to the browser
- The fact renders only after mount (`{fact && ...}`), so SSR output is unchanged and existing petting/bark/hearts interactions are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)